### PR TITLE
fix: 메인 UI 로고 이미지 사이즈 수정

### DIFF
--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -4,9 +4,9 @@ import Kakao_ChatBubble from "../assets/kakao_chatbubble.svg";
 
 function MainPage() {
     return (
-        <div className="w-screen h-screen flex flex-col justify-center items-center gap-16">
+        <div className="h-screen flex flex-col justify-center items-center gap-16">
             <div className="flex flex-col items-center">
-                <img src={Logo} />
+                <img src={Logo} alt="everflow_logo" width={518} />
                 <label className="text-primary-500 font-extrabold text-[32px]">우리가 더 가까워지는 방법</label>
             </div>
 


### PR DESCRIPTION
메인 페이지 로고 이미지 사이즈 가로 518px로 변경했습니다.

<img width="623" height="624" alt="스크린샷 2025-08-29 오후 10 13 03" src="https://github.com/user-attachments/assets/8156b84d-cf67-461d-9a3c-ba80cd698d98" />
